### PR TITLE
fix: state not change when cancel tap

### DIFF
--- a/lib/ui/component/gdg_button.dart
+++ b/lib/ui/component/gdg_button.dart
@@ -219,6 +219,11 @@ class _GdgButtonState extends State<GdgButton> {
           isPressed = false;
         });
       },
+      onTapCancel: () {
+        setState(() {
+          isPressed = false;
+        });
+      },
       child: AnimatedContainer(
         constraints: constraint(variant),
         curve: Curves.easeInOut,


### PR DESCRIPTION
버튼 탭 후 바로 떼는게 아니라 다른곳으로 드래그 후 떼면 cancel처리가 되어 state가 바뀌지 않는 문제 해결